### PR TITLE
change eslint max-len to warning instead of error

### DIFF
--- a/pipeline/.eslintrc.yml
+++ b/pipeline/.eslintrc.yml
@@ -10,3 +10,4 @@ parserOptions:
 rules: 
   require-jsdoc: warn
   no-unused-vars: warn
+  max-len: warn


### PR DESCRIPTION
Max length error might be a little bit too strict in the current phase where there are quite a few ad-hoc solutions, changed to just warning for now